### PR TITLE
Removed unwanted schema from pom.xml

### DIFF
--- a/solution/ts-sr/maven/pom.xml
+++ b/solution/ts-sr/maven/pom.xml
@@ -32,7 +32,6 @@
                     </subjectPatterns>
                     <subjects>
                         <users-value>avro/user.avsc</users-value>
-                        <users-value>avro/user.v3.avsc</users-value>
                     </subjects>
                 </configuration>
             </plugin>


### PR DESCRIPTION
addresses issue from here: https://github.com/confluentinc/training-mtt/issues/126
Removed unwanted schema from `pom.xml`